### PR TITLE
Correct Ruby version needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A tool for the consistent creation of complex CloudFormation templates.
 
 ## Prerequisites
 
- * Ruby 2.1.0+
+ * Ruby 2.2.0+
  * Bundler
 
 ## Installation


### PR DESCRIPTION
I initially tried to run `flight-hangar` using Ruby 2.1.6, which should match the stated required version, however this failed due to the use of the new hash syntax introduced in Ruby 2.2 (like this: `{"foo": "bar"}`). If 2.2.x is used instead then it seems to work fine.
